### PR TITLE
castform(sft): let SftTrainingConfig select the model

### DIFF
--- a/packages/castform/src/castform/platform/client.py
+++ b/packages/castform/src/castform/platform/client.py
@@ -475,6 +475,10 @@ class TrainerClient:
             "dataset": dataset,
             "args": resolved.as_args(),
         }
+        # Sibling of dataset/args, not an arg: the platform resolves topology
+        # from it before validating anything that depends on the topology.
+        if resolved.model is not None:
+            body["model"] = resolved.model
 
         # The MARKER turns eval on and rides the uploaded assets, not the
         # config: no eval.jsonl in the prefix, no eval. Train identity is sent

--- a/packages/castform/src/castform/platform/sft.py
+++ b/packages/castform/src/castform/platform/sft.py
@@ -34,9 +34,21 @@ _LR_DECAY_STYLES = frozenset({"constant", "cosine"})
 # it stays platform-only; these mirror the server's public set.
 _PUBLIC_LORA_RANKS = frozenset({32, 64})
 
-# Megatron needs global_batch_size divisible by the data-parallel width, which
-# is 4 on the fixed SFT topology. Mirrors the server; the server is authority.
-_DATA_PARALLEL_SIZE = 4
+# Megatron needs global_batch_size divisible by the data-parallel width. That
+# width is actor_gpus / CP, and v1 runs at CP1, so it equals the model's actor
+# GPU count. Mirrors the server's SFT_ACTOR_GPUS_BY_MODEL; the server is
+# authority. A stale mirror here does not corrupt a run -- the server still
+# rejects -- but it breaks this class's promise to fail before any request.
+_ACTOR_GPUS_BY_MODEL = {
+    "Qwen/Qwen3.5-4B": 4,
+    "Qwen/Qwen3.5-35B-A3B": 8,
+    "google/gemma-4-26B-A4B-it": 8,
+}
+
+# Absent `model` means the platform default, which is the only model v1 ran.
+_DEFAULT_MODEL = "Qwen/Qwen3.5-4B"
+_SUPPORTED_MODELS = frozenset(_ACTOR_GPUS_BY_MODEL)
+_DATA_PARALLEL_SIZE = _ACTOR_GPUS_BY_MODEL[_DEFAULT_MODEL]
 
 # Context sizing. At or below the v1 ceiling any value is accepted; above it,
 # only the frozen ladder rungs exist. Mirrors the server's shape.
@@ -82,9 +94,10 @@ class UploadedSftAssets:
 class SftTrainingConfig:
     """The genuine caller choices for a v1 SFT run.
 
-    Everything else — model, LoRA rank/alpha, batch size, GPU topology,
-    optimizer, checkpoint layout, stop policy — is platform-owned and not
-    accepted here. Ranges mirror the platform's public argument table so bad
+    ``model`` selects among the models the platform will train; omitting it
+    keeps the platform default, so existing callers are unaffected. Everything
+    else — LoRA rank/alpha, GPU topology, optimizer, checkpoint layout, stop
+    policy — remains platform-owned and is not accepted here. Ranges mirror the platform's public argument table so bad
     values fail before any request; the server remains authoritative.
     """
 
@@ -93,6 +106,8 @@ class SftTrainingConfig:
     max_context_tokens: int = 8192
     save_interval: int = 20
     seed: int = 42
+    # ``None`` means "not sent", so the platform applies its own default.
+    model: str | None = None
     # Optional knobs. ``None`` means "not sent": the field is omitted from
     # ``as_args()``, so the platform stamps nothing and the trainer keeps the
     # model config's value.
@@ -118,6 +133,9 @@ class SftTrainingConfig:
         self._require_context_tokens(self.max_context_tokens)
         self._require_int("save_interval", self.save_interval, 1, 10_000)
         self._require_int("seed", self.seed, 0, 2_147_483_647)
+
+        if self.model is not None and self.model not in _SUPPORTED_MODELS:
+            raise ValueError(f"model must be one of {', '.join(sorted(_SUPPORTED_MODELS))}")
 
         if self.lr_decay_style is not None and self.lr_decay_style not in _LR_DECAY_STYLES:
             raise ValueError(f"lr_decay_style must be one of {', '.join(sorted(_LR_DECAY_STYLES))}")
@@ -151,12 +169,13 @@ class SftTrainingConfig:
                 and not isinstance(self.max_context_tokens, bool)
                 and self.max_context_tokens <= V1_MAX_CONTEXT_TOKENS
             )
-            minimum = _DATA_PARALLEL_SIZE if in_v1_range else 1
+            width = _ACTOR_GPUS_BY_MODEL[self.model or _DEFAULT_MODEL]
+            minimum = width if in_v1_range else 1
             self._require_int("global_batch_size", self.global_batch_size, minimum, 64)
-            if in_v1_range and self.global_batch_size % _DATA_PARALLEL_SIZE:
+            if in_v1_range and self.global_batch_size % width:
                 raise ValueError(
-                    f"global_batch_size must be a multiple of {_DATA_PARALLEL_SIZE} "
-                    "(the data-parallel width of the fixed SFT topology)"
+                    f"global_batch_size must be a multiple of {width} "
+                    f"(the data-parallel width of {self.model or _DEFAULT_MODEL})"
                 )
 
     @staticmethod

--- a/packages/castform/tests/unit/platform/test_sft.py
+++ b/packages/castform/tests/unit/platform/test_sft.py
@@ -579,3 +579,32 @@ class TestBatchSizeAcrossContextBuckets:
         for bad in (0, 65, -4):
             with pytest.raises(ValueError, match="global_batch_size"):
                 SftTrainingConfig(max_context_tokens=131072, global_batch_size=bad)
+
+
+class TestSftModelSelection:
+    """`model` is optional; omitting it must leave v1 callers untouched."""
+
+    def test_omitted_model_is_not_sent(self) -> None:
+        assert SftTrainingConfig().model is None
+
+    def test_supported_models_accepted(self) -> None:
+        for name in ("Qwen/Qwen3.5-4B", "Qwen/Qwen3.5-35B-A3B", "google/gemma-4-26B-A4B-it"):
+            assert SftTrainingConfig(model=name).model == name
+
+    def test_unregistered_model_rejected(self) -> None:
+        with pytest.raises(ValueError, match="model must be one of"):
+            SftTrainingConfig(model="acme/not-a-model")
+
+    def test_batch_width_follows_the_selected_model(self) -> None:
+        # The default keeps the exact v1 rule: multiples of 4.
+        SftTrainingConfig(global_batch_size=8)
+        with pytest.raises(ValueError, match="multiple of 4"):
+            SftTrainingConfig(global_batch_size=6)
+
+        # An 8-GPU model has DP 8 at CP1, so 4 is no longer legal even though it
+        # is legal for the default model. Catching that here is the point of
+        # mirroring the server's table: otherwise the launch fails server-side
+        # after the upload.
+        SftTrainingConfig(model="google/gemma-4-26B-A4B-it", global_batch_size=8)
+        with pytest.raises(ValueError, match="multiple of 8"):
+            SftTrainingConfig(model="google/gemma-4-26B-A4B-it", global_batch_size=4)


### PR DESCRIPTION
Makes `model` a caller choice in the SFT SDK, so `gemma-4-26B-A4B-it` and `Qwen3.5-35B-A3B`
are reachable through `castform` and not only through a hand-rolled SkyPilot launch.

Downstream of castform#397 (trainer registers both models) and castform#398 (platform accepts
a `model` field and derives topology from it). The SDK was the last surface still assuming one
model.

## What was pinned

`SftTrainingConfig`'s docstring said it plainly:

> Everything else — **model**, LoRA rank/alpha, batch size, GPU topology, optimizer,
> checkpoint layout, stop policy — is platform-owned and not accepted here.

True when written; the platform has since changed.

## The change

`model: str | None = None`, omitted from the request when unset — so **every existing caller
is byte-identical** and keeps the platform default.

Two things travel with it:

**The allowlist is mirrored locally.** A bad value fails before the dataset upload rather than
after it, which is how the other ranges in this class already behave. The server stays
authoritative.

**`_DATA_PARALLEL_SIZE` becomes per-model.** This is the part worth reviewing. It gated
`global_batch_size` on a hardcoded `4`:

```python
_DATA_PARALLEL_SIZE = 4  # "the data-parallel width of the fixed SFT topology"
```

DP is `actor_gpus / CP`, and v1 runs at CP1, so the width is the model's actor GPU count —
**8** for both MoE models. Left alone, this class would have accepted
`global_batch_size=4` for a gemma-4 run and let the platform reject it *after* the upload,
which is precisely the failure these local range checks exist to prevent.

`client.py` sends `model` as a sibling of `dataset`/`args`, not inside `args`, because the
platform resolves topology from it before validating anything topology-dependent.

## Testing

Four new cases: omitted-model default, the three supported models, rejection of an
unregistered one, and that batch width follows the selected model (`multiple of 4` for the
default, `multiple of 8` for gemma-4).

**I could not execute them.** This package declares `requires-python = "==3.12.*"` and the
machine I authored on has 3.9.6 — `tests/conftest.py` uses `bool | None`, so collection fails
before any test runs. All three touched files compile under `py_compile`, but CI is the first
real execution. Flagging rather than implying they were run.
