### PR TITLE
release: 0.2.5

### DIFF
--- a/packages/benchmax/pyproject.toml
+++ b/packages/benchmax/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchmax"
-version = "0.2.4"
+version = "0.2.5"
 description = "Platform-independent runtime for grouped LLM environments"
 readme = "README.md"
 authors = [{ name = "benchmax Authors" }]

--- a/packages/castform/pyproject.toml
+++ b/packages/castform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "castform"
-version = "0.2.4"
+version = "0.2.5"
 description = "SDK and CLI for the Castform training platform"
 readme = "README.md"
 authors = [{ name = "castie@castform.com" }]


### PR DESCRIPTION
Version bump so the SDK change in #99 can be published.

`castform` and `benchmax` are both on **0.2.4** on PyPI already, so that version is taken and
nothing can ship without a bump. Both move to **0.2.5**; they have shipped in lockstep and are
currently identical, so I kept that. Split them if it is no longer intended.

## What 0.2.5 carries

- **#99** — `SftTrainingConfig.model`, making `gemma-4-26B-A4B-it` and `Qwen3.5-35B-A3B`
  reachable from the SDK, plus the per-model data-parallel width so a bad `global_batch_size`
  fails locally instead of after the dataset upload
- **#97** — RagEnv reward source-gating (unrelated, already on main)

## Publishing

There is no release automation in this repo — no workflows, no publish target, no documented
release process — so the actual `uv build` / `uv publish` is a manual step with a PyPI token,
and I have deliberately not attempted it. Publishing is irreversible: a version cannot be
replaced once uploaded.