### PR TITLE
castform(rag): decouple corpus-limit detection from the server's cap

### DIFF
--- a/packages/castform/src/castform/rag/corpus/postgres/client.py
+++ b/packages/castform/src/castform/rag/corpus/postgres/client.py
@@ -192,8 +192,8 @@ class CorpusClient:
             raise AuthenticationError(message)
 
         if response.status_code == 400:
-            if "Maximum of 20 corpora" in message:
-                raise CorpusLimitError()
+            if "corpora per user" in message:
+                raise CorpusLimitError(message=message)
             if "Chunk limit exceeded" in message:
                 raise CorpusAPIError(message, 400)
             raise CorpusAPIError(message, 400)
@@ -215,7 +215,7 @@ class CorpusClient:
             Corpus object with id, name, timestamps
 
         Raises:
-            CorpusLimitError: If max 20 corpora limit reached
+            CorpusLimitError: If the per-user corpus limit is reached
             AuthenticationError: If API key is invalid
         """
         response = await self._request("POST", "/v1/corpora", json={"name": name})
@@ -312,7 +312,7 @@ class CorpusClient:
     async def _interactive_corpus_selection(self, new_name: str, existing: list[Corpus]) -> Corpus:
         """Interactive corpus selection for Jupyter notebooks."""
         print("\n" + "=" * 60)
-        print("CORPUS LIMIT REACHED (max 5)")
+        print("CORPUS LIMIT REACHED")
         print("=" * 60)
         print("\nExisting corpora:")
 

--- a/packages/castform/src/castform/rag/corpus/postgres/exceptions.py
+++ b/packages/castform/src/castform/rag/corpus/postgres/exceptions.py
@@ -24,10 +24,14 @@ class AuthenticationError(CorpusAPIError):
 
 
 class CorpusLimitError(CorpusAPIError):
-    """Maximum corpus limit (20) reached."""
+    """Per-user corpus limit reached. The server owns the number, not us."""
 
-    def __init__(self, existing_corpora: list[Corpus] | None = None):
-        super().__init__("Maximum of 20 corpora per user reached", 400)
+    def __init__(
+        self,
+        existing_corpora: list[Corpus] | None = None,
+        message: str | None = None,
+    ):
+        super().__init__(message or "Per-user corpus limit reached", 400)
         self.existing_corpora = existing_corpora or []
 
 


### PR DESCRIPTION
Prep for raising `CORPUS_LIMIT_PER_USER` in corpora-service (castform#TBD, 5 → 50).

`_handle_response_errors` matched the literal string `"Maximum of 20 corpora"`. The server sends `Maximum of <N> corpora per user reached`, so any cap change downgrades the 400 to a generic `CorpusAPIError` and `get_or_create_corpus(on_limit=...)` stops firing — `"prompt"`, `"oldest"` and `"error"` all become dead paths, including the `castform corpus ingest` verb that relies on `on_limit="error"` to surface the cap non-interactively.

This is already broken against deployed prod, which runs the old image and sends `Maximum of 5 corpora`. Matching on the number-free part fixes it for both the current and the new cap.

- match `"corpora per user"` instead of the number
- carry the server's own message into `CorpusLimitError` rather than hard-coding one
- drop the stale numbers from the docstrings and the notebook banner (the module said 5 in the banner and 20 in the docstrings)

## checks
- `ruff check` / `ruff format --check` clean on the touched module
- `pytest packages/castform/tests/unit/rag/corpus` — 290 passed
- full unit suite: 1171 passed, 1 pre-existing failure (`test_sft.py::TestSftModelSelection::test_batch_width_follows_the_selected_model`, red on clean main too)