### PR TITLE
feat(aime): add Cloudflare sandbox provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,12 @@ env/
 venv/
 ENV/
 
+# Node / Cloudflare Workers
+node_modules/
+.wrangler/
+.dev.vars
+.dev.vars.*
+
 # IDE
 .idea/
 .vscode/

--- a/examples/aime/README.md
+++ b/examples/aime/README.md
@@ -1,6 +1,6 @@
 # aime
 
-a harbor environment built with [`HarborEnv`](../../packages/benchmax/src/benchmax/envs/harbor/README.md) where an offline-installed mini-swe agent solves AIME competition math inside modal sandboxes.
+a harbor environment built with [`HarborEnv`](../../packages/benchmax/src/benchmax/envs/harbor/README.md) where an offline-installed mini-swe agent solves AIME competition math inside Modal or prepared Cloudflare sandboxes.
 
 ## example task
 
@@ -16,6 +16,8 @@ answer: 738
 
 ## launch training
 
+### Modal
+
 ```bash
 cd examples/aime
 
@@ -30,23 +32,55 @@ uv run python main.py launch --modal-token-id $MODAL_TOKEN_ID --modal-token-secr
 uv run python main.py validate --modal-token-id $MODAL_TOKEN_ID --modal-token-secret $MODAL_TOKEN_SECRET
 ```
 
-the dataset (aime/aime@latest) resolves through harbor at trainer runtime, so launch only uploads the environment bundle, validates it, then asks for confirmation before spending credits (pass `--yes` to skip). the modal credentials are mandatory arguments and are bundled into the constructor args so trainer-side trials can reach modal.
+### Cloudflare Standard-2
 
-validate stops after the checks: it runs sample rollouts with a standard model, locally and in a hosted sandbox, just to confirm the environment runs end to end. both locations run real modal sandbox trials.
+All 60 tasks in `aime/aime@latest` have the same Dockerfile-only image, so the
+Cloudflare option is a prepared-image deployment rather than a dynamic builder.
+Deploy [`cloudflare/`](cloudflare/) once, then use the returned Worker URL and
+the bearer key supplied through `SANDBOX_API_KEY`:
+
+```bash
+cd examples/aime/cloudflare
+npm install
+npx wrangler secret put SANDBOX_API_KEY
+npm run deploy
+
+cd ..
+export CLOUDFLARE_SANDBOX_API_URL=https://benchmax-aime-sandbox.<subdomain>.workers.dev
+export CLOUDFLARE_SANDBOX_API_KEY=<same-bearer-key>
+
+uv run python main.py validate --sandbox-provider cloudflare
+uv run python main.py launch --sandbox-provider cloudflare
+```
+
+The Worker uses Standard-2 containers, disables the warm pool, and sleeps idle
+containers after 30 minutes. The adapter verifies every task Dockerfile before
+starting a prepared container; a changed image or extra build-context file
+fails closed.
+
+the dataset (aime/aime@latest) resolves through harbor at trainer runtime, so launch only uploads the environment bundle, validates it, then asks for confirmation before spending credits (pass `--yes` to skip). credentials for the selected sandbox provider are bundled into the constructor args.
+
+validate stops after the checks: it runs sample rollouts with a standard model, locally and in a hosted sandbox, just to confirm the environment runs end to end. both locations run real trials with the selected sandbox provider.
 
 ## environment
 
 ```python
 class AimeMiniSweHarborEnv(HarborEnv):
-    def __init__(..., harness=None):
+    def __init__(..., sandbox_provider="modal", harness=None):
         super().__init__(
             dataset=DatasetConfig(name="aime/aime", ref="latest"),
             trial=HarborTrialTemplate(
                 agent=harness or mini_swe_harness(),
-                environment=TrialEnvironmentConfig(type=EnvironmentType.MODAL),
+                environment=(
+                    TrialEnvironmentConfig(type=EnvironmentType.MODAL)
+                    if sandbox_provider == "modal"
+                    else TrialEnvironmentConfig(
+                        import_path="cloudflare_environment:AimeCloudflareEnvironment"
+                    )
+                ),
                 verifier=TrialVerifierConfig(),
             ),
-            sandbox_credentials=ModalCredentials(...),
+            sandbox_credentials=...,
         )
 ```
 

--- a/examples/aime/README.md
+++ b/examples/aime/README.md
@@ -37,12 +37,17 @@ uv run python main.py validate --modal-token-id $MODAL_TOKEN_ID --modal-token-se
 All 60 tasks in `aime/aime@latest` have the same Dockerfile-only image, so the
 Cloudflare option is a prepared-image deployment rather than a dynamic builder.
 Deploy [`cloudflare/`](cloudflare/) once, then use the returned Worker URL and
-the bearer key supplied through `SANDBOX_API_KEY`:
+the bearer key supplied through `SANDBOX_API_KEY`. Docker must be running, and
+Wrangler must be authenticated for the target account (for automation, export
+`CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`):
 
 ```bash
 cd examples/aime/cloudflare
 npm install
+# This creates and immediately deploys a Worker version with the secret.
 npx wrangler secret put SANDBOX_API_KEY
+# The explicit deploy builds and pushes the prepared container image; Wrangler
+# preserves the secret set above.
 npm run deploy
 
 cd ..

--- a/examples/aime/cloudflare/Dockerfile
+++ b/examples/aime/cloudflare/Dockerfile
@@ -1,0 +1,13 @@
+# Every task in aime/aime@latest uses this exact, Dockerfile-only image.
+FROM ghcr.io/laude-institute/t-bench/ubuntu-24-04:20250624
+
+# The bridge binary and Worker package must use the same Sandbox SDK version.
+COPY --from=docker.io/cloudflare/sandbox:0.12.9 /container-server/sandbox /sandbox
+
+RUN mkdir -p /workspace /app /logs/agent /logs/verifier /logs/artifacts \
+    /tests /solution /harbor/skills \
+    && chmod 777 /workspace /app /logs /logs/agent /logs/verifier \
+    /logs/artifacts /tests /solution /harbor /harbor/skills
+
+WORKDIR /app
+ENTRYPOINT ["/sandbox"]

--- a/examples/aime/cloudflare/README.md
+++ b/examples/aime/cloudflare/README.md
@@ -1,0 +1,18 @@
+# AIME Cloudflare Sandbox bridge
+
+This is a prepared-image deployment for `aime/aime@latest`. All 60 tasks use
+the same Dockerfile-only Ubuntu image, so no task-specific image build or
+upload is needed. Wrangler builds the image and pushes it to Cloudflare during
+deployment. Containers use Standard-2, have no warm pool, and sleep after 30
+minutes of inactivity.
+
+```bash
+npm install
+npx wrangler secret put SANDBOX_API_KEY
+npm run deploy
+```
+
+Save the deployed Worker URL and bearer value as
+`CLOUDFLARE_SANDBOX_API_URL` and `CLOUDFLARE_SANDBOX_API_KEY`. The Wrangler
+deployment credential needs `Workers Scripts: Edit`, `Workers Containers:
+Edit`, and `Account Settings: Read` for the target account.

--- a/examples/aime/cloudflare/README.md
+++ b/examples/aime/cloudflare/README.md
@@ -6,9 +6,16 @@ upload is needed. Wrangler builds the image and pushes it to Cloudflare during
 deployment. Containers use Standard-2, have no warm pool, and sleep after 30
 minutes of inactivity.
 
+Docker must be running locally. Wrangler must also be authenticated for the
+target account; for non-interactive deployment, export `CLOUDFLARE_ACCOUNT_ID`
+and `CLOUDFLARE_API_TOKEN`.
+
 ```bash
 npm install
+# This creates and immediately deploys a Worker version with the secret.
 npx wrangler secret put SANDBOX_API_KEY
+# This explicit deploy builds and pushes the prepared container image. Wrangler
+# preserves the secret set above.
 npm run deploy
 ```
 

--- a/examples/aime/cloudflare/package-lock.json
+++ b/examples/aime/cloudflare/package-lock.json
@@ -1,0 +1,1638 @@
+{
+  "name": "benchmax-aime-cloudflare-sandbox",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "benchmax-aime-cloudflare-sandbox",
+      "version": "0.1.0",
+      "dependencies": {
+        "@cloudflare/sandbox": "0.12.9"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^5.20260828.1",
+        "@types/node": "^24.10.1",
+        "typescript": "^5.9.2",
+        "wrangler": "^4.34.0"
+      }
+    },
+    "node_modules/@cloudflare/containers": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.7.tgz",
+      "integrity": "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==",
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/sandbox": {
+      "version": "0.12.9",
+      "resolved": "https://registry.npmjs.org/@cloudflare/sandbox/-/sandbox-0.12.9.tgz",
+      "integrity": "sha512-JlCQ8adVaHT3TrZO13X6US2LJTyQ4YvoEZpfh5EewRqcxPfMHZNJPB/1dsRdiFqmtzpz+lMxGazSUa2H/g2IKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cloudflare/containers": "^0.3.5",
+        "aws4fetch": "^1.0.20",
+        "capnweb": "^0.8.0",
+        "hono": "^4.13.0"
+      },
+      "peerDependencies": {
+        "@openai/agents": "^0.3.3",
+        "@opencode-ai/sdk": "^1.1.40",
+        "@xterm/xterm": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@openai/agents": {
+          "optional": true
+        },
+        "@opencode-ai/sdk": {
+          "optional": true
+        },
+        "@xterm/xterm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260828.1.tgz",
+      "integrity": "sha512-CVd+xPhqUESg8Xhq09TZx0wl4FSirfJGOzvbPz2yHhBIvmNHFFQkSN3rkd7wEwnhQQk37Xi0/aD6ykPLJbmGiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260828.1.tgz",
+      "integrity": "sha512-5HDPXRM152vU5JveByGFk34X57TVyIsfp4cabepAf45DC0MKvm52ucJqAjW1h8bvW4X+zRw9GU35OHF9FEC9Ww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260828.1.tgz",
+      "integrity": "sha512-MQ1Ll9P7F72HHUKizbb7BlDfbY8fRoNMpbIpZoU6uKsSkneFICWSKv6UlgU9EQZ+w0i7TMa12iUgJ8l29eRI9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260828.1.tgz",
+      "integrity": "sha512-FBTaUQ1xcU9jcp4OyBPcH8x0QiFvc1iuZL2GkD8zp2q1WyTVHYOptRDQUU+cuHjt0rQ2EIKVPBjahPxfa0joBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260828.1.tgz",
+      "integrity": "sha512-yvr77hC7dUbvK5K+SCg062kkPq3sx+drV1PcgHslzHDYcJBtT0V3X80qLE49LW1vq2svaeNmsVQS+vHsqWu8cQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260831.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260831.1.tgz",
+      "integrity": "sha512-yXg4pwfYjhsDH9rYc3qZ3K+z62DCSvO/aj7GiZo6AyDeWGZpyFRpPMYcQ6LF/zfaf1x0Ngw2gSqL8JjuUtMGlA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/capnweb": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/capnweb/-/capnweb-0.8.0.tgz",
+      "integrity": "sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==",
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260828.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260828.0-alpha.tgz",
+      "integrity": "sha512-6nbxhZEcz/UET3Y1OnYPsrAUjUmuFoib3ynUqteRdn1YnDxsLg8cwgZJZCk9QmtOmGzXwzXzgE/d/C0dJAPtVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260828.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260828.1.tgz",
+      "integrity": "sha512-pB9yvt0kkwZDAGZHmpY59r0o3hM0DzdW6BJERqwZOhunZ3ssOyDSgQxOQer2cSZW4YCFeOTIQYN1qwhK5wv/Cw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260828.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260828.1",
+        "@cloudflare/workerd-linux-64": "1.20260828.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260828.1",
+        "@cloudflare/workerd-windows-64": "1.20260828.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.127.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.127.1.tgz",
+      "integrity": "sha512-OzsiNgaI8i681L/+KnAKc+uEZ5D57xK5JuNvCOpRKICF4/5Q3Cu1oTGuUiT/f3GDUqQb3gzXNT0tfOHGMEtknw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260828.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260828.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260828.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/examples/aime/cloudflare/package.json
+++ b/examples/aime/cloudflare/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "benchmax-aime-cloudflare-sandbox",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@cloudflare/sandbox": "0.12.9"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^5.20260828.1",
+    "@types/node": "^24.10.1",
+    "typescript": "^5.9.2",
+    "wrangler": "^4.34.0"
+  }
+}

--- a/examples/aime/cloudflare/src/index.ts
+++ b/examples/aime/cloudflare/src/index.ts
@@ -1,0 +1,14 @@
+import { Sandbox as CloudflareSandbox } from "@cloudflare/sandbox";
+import { bridge } from "@cloudflare/sandbox/bridge";
+
+export { WarmPool } from "@cloudflare/sandbox/bridge";
+
+export class Sandbox extends CloudflareSandbox {
+	override sleepAfter = "30m";
+}
+
+export default bridge({
+	async fetch(): Promise<Response> {
+		return new Response("BenchMax AIME Cloudflare Sandbox bridge");
+	},
+});

--- a/examples/aime/cloudflare/tsconfig.json
+++ b/examples/aime/cloudflare/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/aime/cloudflare/wrangler.jsonc
+++ b/examples/aime/cloudflare/wrangler.jsonc
@@ -1,0 +1,38 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "benchmax-aime-sandbox",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-08-29",
+  "compatibility_flags": ["nodejs_compat"],
+  "workers_dev": true,
+  "observability": {
+    "enabled": true,
+    "traces": { "enabled": false }
+  },
+  "containers": [
+    {
+      "class_name": "Sandbox",
+      "image": "./Dockerfile",
+      "instance_type": "standard-2",
+      "max_instances": 128
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      { "class_name": "Sandbox", "name": "Sandbox" },
+      { "class_name": "WarmPool", "name": "WarmPool" }
+    ]
+  },
+  "migrations": [
+    { "new_sqlite_classes": ["Sandbox"], "tag": "v1" },
+    { "new_sqlite_classes": ["WarmPool"], "tag": "v2" }
+  ],
+  "vars": {
+    "SANDBOX_TRANSPORT": "rpc",
+    "WARM_POOL_TARGET": "0",
+    "WARM_POOL_REFRESH_INTERVAL": "10000",
+    "WARM_POOL_MAX_INSTANCES": "128",
+    "WARM_POOL_SCALE_BATCH_SIZE": "5"
+  },
+  "preview_urls": false
+}

--- a/examples/aime/cloudflare_environment.py
+++ b/examples/aime/cloudflare_environment.py
@@ -1,0 +1,150 @@
+"""AIME's prepared Harbor image exposed through Cloudflare Sandbox bridge."""
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+from typing import Any
+
+from cloudflare_transport import CloudflareSandbox
+from harbor.environments.base import BaseEnvironment, ExecResult
+from harbor.environments.capabilities import EnvironmentCapabilities
+
+AIME_IMAGE = "ghcr.io/laude-institute/t-bench/ubuntu-24-04:20250624"
+EXPECTED_DOCKERFILE = (
+    f"FROM {AIME_IMAGE}",
+    "WORKDIR /app",
+    "ENV TEST_DIR=/tests",
+)
+
+
+def validate_aime_environment(environment_dir: Path | str) -> None:
+    """Fail closed unless a task matches the prepared AIME image exactly."""
+
+    root = Path(environment_dir)
+    dockerfile = root / "Dockerfile"
+    if not dockerfile.is_file():
+        raise FileNotFoundError(f"AIME Dockerfile not found: {dockerfile}")
+    instructions = tuple(
+        line.strip()
+        for line in dockerfile.read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    )
+    if instructions != EXPECTED_DOCKERFILE:
+        raise ValueError(
+            "Cloudflare AIME adapter only supports the verified fixed Dockerfile; "
+            f"received {instructions!r}"
+        )
+    unexpected = sorted(child.name for child in root.iterdir() if child.name != "Dockerfile")
+    if unexpected:
+        raise ValueError(
+            "Cloudflare AIME adapter only supports a Dockerfile-only build context; "
+            f"received {unexpected!r}"
+        )
+
+
+class AimeCloudflareEnvironment(BaseEnvironment):
+    """Run AIME's fixed image in a prepared Cloudflare Standard-2 container."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self._api_url = os.environ.get("CLOUDFLARE_SANDBOX_API_URL", "").rstrip("/")
+        self._api_key = os.environ.get("CLOUDFLARE_SANDBOX_API_KEY", "")
+        self._sandbox: CloudflareSandbox | None = None
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def type() -> str:
+        return "cloudflare"
+
+    @property
+    def capabilities(self) -> EnvironmentCapabilities:
+        return EnvironmentCapabilities()
+
+    @classmethod
+    def preflight(cls) -> None:
+        missing = [
+            name
+            for name in (
+                "CLOUDFLARE_SANDBOX_API_URL",
+                "CLOUDFLARE_SANDBOX_API_KEY",
+            )
+            if not os.environ.get(name)
+        ]
+        if missing:
+            raise SystemExit(f"missing Cloudflare Sandbox setting(s): {', '.join(missing)}")
+
+    def _validate_definition(self) -> None:
+        if not self._api_url or not self._api_key:
+            raise ValueError(
+                "Cloudflare Sandbox requires CLOUDFLARE_SANDBOX_API_URL and "
+                "CLOUDFLARE_SANDBOX_API_KEY"
+            )
+        validate_aime_environment(self.environment_dir)
+
+    def _inner(self) -> CloudflareSandbox:
+        if self._sandbox is None:
+            raise RuntimeError("Cloudflare sandbox has not been started")
+        return self._sandbox
+
+    async def start(self, force_build: bool) -> None:
+        if force_build:
+            self.logger.info(
+                "force_build ignored: the Cloudflare Worker owns the prepared AIME image"
+            )
+        self._sandbox = CloudflareSandbox(self._api_url, self._api_key)
+        try:
+            await self._sandbox.start()
+        except BaseException:
+            self._sandbox = None
+            raise
+
+    async def stop(self, delete: bool) -> None:
+        sandbox, self._sandbox = self._sandbox, None
+        if sandbox is not None:
+            await sandbox.close(delete=delete)
+
+    async def exec(
+        self,
+        command: str,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_sec: int | None = None,
+        user: str | int | None = None,
+    ) -> ExecResult:
+        merged_env = self._merge_env(env) or {}
+        actual_cwd = cwd or self.task_env_config.workdir or "/app"
+        resolved_user = self._resolve_user(user)
+        if resolved_user not in (None, "root", 0, "0"):
+            exports = [
+                f"export {name}={shlex.quote(str(value))}" for name, value in merged_env.items()
+            ]
+            script = " && ".join([*exports, f"cd {shlex.quote(actual_cwd)}", command])
+            command = (
+                f"exec su -s /bin/bash {shlex.quote(str(resolved_user))} -c {shlex.quote(script)}"
+            )
+            actual_cwd = "/app"
+            merged_env = {}
+        result = await self._inner().run_command(
+            command,
+            workdir=actual_cwd,
+            env=merged_env,
+            timeout=timeout_sec,
+        )
+        return ExecResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            return_code=result.exit_code,
+        )
+
+    async def upload_file(self, source_path: Path | str, target_path: str) -> None:
+        await self._inner().upload_file(source_path, target_path)
+
+    async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
+        await self._inner().upload_dir(source_dir, target_dir)
+
+    async def download_file(self, source_path: str, target_path: Path | str) -> None:
+        await self._inner().download_file(source_path, target_path)
+
+    async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
+        await self._inner().download_dir(source_dir, target_dir)

--- a/examples/aime/cloudflare_transport.py
+++ b/examples/aime/cloudflare_transport.py
@@ -1,0 +1,420 @@
+"""HTTP client for the self-deployed Cloudflare Sandbox bridge."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import random
+import re
+import shlex
+import tarfile
+import tempfile
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from urllib.parse import quote
+
+import httpx
+
+TRANSFER_ROOT = "/workspace/.harbor-transfer"
+MAX_DIRECT_WRITE = 31 * 1024 * 1024
+ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+TRANSIENT_START_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+MAX_START_RETRY_WAIT_SECONDS = 60.0
+MAX_START_RETRY_DELAY_SECONDS = 10.0
+
+logger = logging.getLogger(__name__)
+
+
+class CloudflareHTTPError(RuntimeError):
+    """An HTTP failure from the authenticated Sandbox bridge."""
+
+    def __init__(self, operation: str, status_code: int, detail: str) -> None:
+        super().__init__(f"Cloudflare {operation} failed (HTTP {status_code}): {detail[:500]}")
+        self.status_code = status_code
+
+
+@dataclass(frozen=True, slots=True)
+class CommandResult:
+    stdout: str
+    stderr: str
+    exit_code: int
+
+    @property
+    def return_code(self) -> int:
+        """Harbor spells the same field differently."""
+        return self.exit_code
+
+
+class CloudflareSandbox:
+    """One isolated sandbox behind Cloudflare's authenticated HTTP bridge."""
+
+    provider = "cloudflare"
+
+    def __init__(
+        self,
+        api_url: str,
+        api_key: str,
+        *,
+        max_stream_output_bytes: int | None = None,
+    ) -> None:
+        normalized_url = api_url.strip().rstrip("/")
+        if not normalized_url.startswith(("https://", "http://")):
+            raise ValueError("Cloudflare Sandbox api_url must be an HTTP(S) URL")
+        if not api_key:
+            raise ValueError("Cloudflare Sandbox api_key must be non-empty")
+        if max_stream_output_bytes is not None and max_stream_output_bytes < 1:
+            raise ValueError("max_stream_output_bytes must be positive")
+        self.api_url = normalized_url
+        self._api_key = api_key
+        self.max_stream_output_bytes = max_stream_output_bytes
+        self._sandbox_id: str | None = None
+        self._client: httpx.AsyncClient | None = None
+
+    @property
+    def sandbox_id(self) -> str:
+        if self._sandbox_id is None:
+            raise RuntimeError("Cloudflare sandbox has not been started")
+        return self._sandbox_id
+
+    def _http(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=self.api_url,
+                headers={"Authorization": f"Bearer {self._api_key}"},
+                timeout=httpx.Timeout(connect=30, read=None, write=120, pool=30),
+            )
+        return self._client
+
+    def _sandbox_path(self, suffix: str = "") -> str:
+        return f"/v1/sandbox/{self.sandbox_id}{suffix}"
+
+    async def start(self) -> None:
+        """Create one sandbox from the bridge Worker's prepared image."""
+        if self._sandbox_id is not None:
+            raise RuntimeError("Cloudflare sandbox is already started")
+        response = await self._http().post("/v1/sandbox")
+        self._raise_for_status(response, "create sandbox")
+        sandbox_id = response.json().get("id")
+        if not isinstance(sandbox_id, str) or not sandbox_id:
+            raise RuntimeError("Cloudflare bridge returned no sandbox ID")
+        self._sandbox_id = sandbox_id
+        try:
+            setup = await self._run_initial_setup()
+            if setup.exit_code != 0:
+                raise RuntimeError(f"Cloudflare sandbox setup failed: {setup.stderr}")
+        except BaseException:
+            try:
+                await self.cleanup()
+            except Exception:
+                # Preserve the trial's real failure. A best-effort DELETE after a
+                # failed allocation must not replace it with a cleanup exception.
+                logger.warning("Cloudflare sandbox cleanup failed", exc_info=True)
+            raise
+
+    async def _run_initial_setup(self) -> CommandResult:
+        """Allocate the container with Modal-style bounded throttle backoff.
+
+        The bridge allocates on the first exec rather than on POST /sandbox. This
+        command is intentionally idempotent, so it is safe to replay against the
+        same sandbox ID. Arbitrary agent commands are never retried.
+        """
+        command = (
+            "mkdir -p /workspace /app /logs/agent /logs/verifier /logs/artifacts "
+            "/tests /solution /harbor/skills "
+            f"{shlex.quote(TRANSFER_ROOT)} && "
+            "chmod 777 /workspace /app /logs /logs/agent /logs/verifier "
+            "/logs/artifacts /tests /solution /harbor /harbor/skills"
+        )
+        delay = 1.0
+        waited = 0.0
+        while True:
+            try:
+                return await self.run_command(command, timeout=120)
+            except CloudflareHTTPError as error:
+                remaining = MAX_START_RETRY_WAIT_SECONDS - waited
+                if error.status_code not in TRANSIENT_START_STATUS_CODES or remaining <= 0:
+                    raise
+                sleep_for = min(remaining, random.uniform(0.5, 1.5) * delay)
+                logger.warning(
+                    "Cloudflare sandbox allocation returned HTTP %s; retrying in %.1fs",
+                    error.status_code,
+                    sleep_for,
+                )
+                await asyncio.sleep(sleep_for)
+                waited += sleep_for
+                delay = min(delay * 2, MAX_START_RETRY_DELAY_SECONDS)
+
+    async def cleanup(self) -> None:
+        """Delete this sandbox and close its HTTP transport; safe to call twice."""
+        await self.close(delete=True)
+
+    async def close(self, *, delete: bool) -> None:
+        """Close the client, optionally deleting the remote sandbox first."""
+        try:
+            if delete and self._sandbox_id is not None:
+                response = await self._http().delete(self._sandbox_path())
+                if response.status_code not in (204, 404):
+                    self._raise_for_status(response, "destroy sandbox")
+        finally:
+            self._sandbox_id = None
+            if self._client is not None:
+                await self._client.aclose()
+                self._client = None
+
+    async def run_command(
+        self,
+        command: str,
+        *,
+        workdir: str = "/workspace",
+        timeout: float | None = None,
+        max_output_bytes: int | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        """Execute a shell command and parse the bridge's SSE result stream."""
+        exports: list[str] = []
+        for name, value in (env or {}).items():
+            if not ENV_NAME.fullmatch(name):
+                raise ValueError(f"invalid environment variable name: {name!r}")
+            exports.append(f"export {name}={shlex.quote(str(value))}")
+        script = " && ".join([*exports, f"cd {shlex.quote(workdir)}", command])
+        timeout_ms = None if timeout is None else max(1, int(timeout * 1000))
+        payload: dict[str, object] = {
+            "argv": ["bash", "-lc", script],
+            "cwd": "/workspace",
+        }
+        if timeout_ms is not None:
+            payload["timeout_ms"] = timeout_ms
+
+        limit = max_output_bytes if max_output_bytes is not None else self.max_stream_output_bytes
+        stdout: list[str] = []
+        stderr: list[str] = []
+        stdout_size = 0
+        stderr_size = 0
+        exit_code: int | None = None
+        request_timeout = None if timeout is None else timeout + 30
+
+        def consume(event: str, data: str) -> None:
+            nonlocal exit_code, stdout_size, stderr_size
+            if event in {"stdout", "stderr"}:
+                decoded = base64.b64decode(data).decode("utf-8", errors="replace")
+                target = stdout if event == "stdout" else stderr
+                size = stdout_size if event == "stdout" else stderr_size
+                if limit is not None:
+                    remaining = max(0, limit - size)
+                    decoded = decoded[:remaining]
+                target.append(decoded)
+                if event == "stdout":
+                    stdout_size += len(decoded)
+                else:
+                    stderr_size += len(decoded)
+            elif event == "exit":
+                exit_code = int(json.loads(data)["exit_code"])
+            elif event == "error":
+                try:
+                    detail = json.loads(data).get("error", data)
+                except json.JSONDecodeError:
+                    detail = data
+                raise RuntimeError(f"Cloudflare sandbox exec failed: {detail}")
+
+        async with self._http().stream(
+            "POST",
+            self._sandbox_path("/exec"),
+            json=payload,
+            timeout=request_timeout,
+        ) as response:
+            if response.is_error:
+                # Streaming responses are not readable through response.text until
+                # explicitly consumed. Read the bridge's pool error before raising.
+                await response.aread()
+            self._raise_for_status(response, "execute command")
+            event: str | None = None
+            data_lines: list[str] = []
+            async for line in response.aiter_lines():
+                if line == "":
+                    if event is not None:
+                        consume(event, "\n".join(data_lines))
+                    event = None
+                    data_lines = []
+                elif line.startswith("event:"):
+                    event = line[6:].strip()
+                elif line.startswith("data:"):
+                    data_lines.append(line[5:].lstrip())
+            if event is not None:
+                consume(event, "\n".join(data_lines))
+
+        if exit_code is None:
+            raise RuntimeError("Cloudflare sandbox exec stream ended without an exit code")
+        return CommandResult(stdout="".join(stdout), stderr="".join(stderr), exit_code=exit_code)
+
+    async def write_file(
+        self,
+        target_path: str,
+        content: bytes | str,
+        *,
+        executable: bool = False,
+    ) -> CommandResult:
+        payload = content.encode() if isinstance(content, str) else content
+        mode = 0o755 if executable else 0o644
+        await self._write_bytes(payload, target_path, mode=mode)
+        return CommandResult(stdout="", stderr="", exit_code=0)
+
+    async def upload_file(self, source_path: Path | str, target_path: str) -> None:
+        source = Path(source_path)
+        if not source.is_file():
+            raise FileNotFoundError(source)
+        await self._write_bytes(
+            source.read_bytes(), target_path, mode=source.stat().st_mode & 0o777
+        )
+
+    async def _write_bytes(self, content: bytes, target_path: str, *, mode: int) -> None:
+        target = str(PurePosixPath(target_path))
+        transfer_id = uuid.uuid4().hex
+        direct = target == "/workspace" or target.startswith("/workspace/")
+        staged_target = target if direct else f"{TRANSFER_ROOT}/{transfer_id}.file"
+        await self._upload_bytes(content, staged_target)
+        command = f"chmod {mode:o} {shlex.quote(staged_target)}"
+        if not direct:
+            command += (
+                f" && mkdir -p {shlex.quote(str(PurePosixPath(target).parent))}"
+                f" && mv {shlex.quote(staged_target)} {shlex.quote(target)}"
+            )
+        result = await self.run_command(command, timeout=120)
+        if result.exit_code != 0:
+            raise RuntimeError(f"failed to finalize upload to {target}: {result.stderr}")
+
+    async def _upload_bytes(self, content: bytes, target: str) -> None:
+        parent = str(PurePosixPath(target).parent)
+        mkdir = await self.run_command(f"mkdir -p {shlex.quote(parent)}", timeout=120)
+        if mkdir.exit_code != 0:
+            raise RuntimeError(f"failed to create upload directory: {mkdir.stderr}")
+        if len(content) <= MAX_DIRECT_WRITE:
+            response = await self._http().put(
+                self._file_path(target),
+                content=content,
+                headers={"Content-Type": "application/octet-stream"},
+            )
+            self._raise_for_status(response, f"upload {target}")
+            return
+
+        parts_dir = f"{TRANSFER_ROOT}/{uuid.uuid4().hex}.parts"
+        make_parts = await self.run_command(f"mkdir -p {shlex.quote(parts_dir)}", timeout=120)
+        if make_parts.exit_code != 0:
+            raise RuntimeError(f"failed to create upload parts directory: {make_parts.stderr}")
+        part_paths: list[str] = []
+        for index, offset in enumerate(range(0, len(content), MAX_DIRECT_WRITE)):
+            part = f"{parts_dir}/{index:06d}"
+            response = await self._http().put(
+                self._file_path(part),
+                content=content[offset : offset + MAX_DIRECT_WRITE],
+                headers={"Content-Type": "application/octet-stream"},
+            )
+            self._raise_for_status(response, f"upload part {index}")
+            part_paths.append(part)
+        command = (
+            f"cat {' '.join(shlex.quote(path) for path in part_paths)} > "
+            f"{shlex.quote(target)} && rm -rf {shlex.quote(parts_dir)}"
+        )
+        result = await self.run_command(command, timeout=300)
+        if result.exit_code != 0:
+            raise RuntimeError(f"failed to join upload parts: {result.stderr}")
+
+    async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
+        source = Path(source_dir)
+        if not source.is_dir():
+            raise FileNotFoundError(source)
+        remote_archive = f"{TRANSFER_ROOT}/{uuid.uuid4().hex}.tar.gz"
+        with tempfile.TemporaryDirectory(prefix="cloudflare-upload-") as tmp:
+            archive = Path(tmp) / "upload.tar.gz"
+            with tarfile.open(archive, "w:gz") as tar:
+                for child in source.iterdir():
+                    tar.add(child, arcname=child.name)
+            await self.upload_file(archive, remote_archive)
+        result = await self.run_command(
+            f"mkdir -p {shlex.quote(target_dir)} && "
+            f"tar xzf {shlex.quote(remote_archive)} --no-same-owner "
+            f"-C {shlex.quote(target_dir)} && rm -f {shlex.quote(remote_archive)}",
+            timeout=300,
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(f"failed to unpack directory upload: {result.stderr}")
+
+    async def read_file(self, source_path: str, *, max_bytes: int | None = None) -> CommandResult:
+        try:
+            content = await self._download_bytes(source_path)
+        except FileNotFoundError as error:
+            return CommandResult(stdout="", stderr=str(error), exit_code=1)
+        if max_bytes is not None:
+            content = content[:max_bytes]
+        return CommandResult(
+            stdout=content.decode("utf-8", errors="replace"),
+            stderr="",
+            exit_code=0,
+        )
+
+    async def download_file(self, source_path: str, target_path: Path | str) -> None:
+        content = await self._download_bytes(source_path)
+        target = Path(target_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
+    async def _download_bytes(self, source_path: str) -> bytes:
+        source = str(PurePosixPath(source_path))
+        # Cloudflare Sandbox 0.12.x returns HTTP 200 with an empty body when a
+        # file does not exist. Check inside the container first so Harbor does
+        # not record a missing required artifact as a successful zero-byte
+        # download.
+        exists = await self.run_command(f"test -f {shlex.quote(source)}", timeout=120)
+        if exists.exit_code != 0:
+            raise FileNotFoundError(source)
+        staged = source
+        cleanup = False
+        if not (source == "/workspace" or source.startswith("/workspace/")):
+            staged = f"{TRANSFER_ROOT}/{uuid.uuid4().hex}.download"
+            result = await self.run_command(
+                f"cp {shlex.quote(source)} {shlex.quote(staged)}", timeout=120
+            )
+            if result.exit_code != 0:
+                raise FileNotFoundError(f"failed to stage download of {source}: {result.stderr}")
+            cleanup = True
+        try:
+            response = await self._http().get(self._file_path(staged))
+            if response.status_code == 404:
+                raise FileNotFoundError(source)
+            self._raise_for_status(response, f"download {source}")
+            return response.content
+        finally:
+            if cleanup:
+                await self.run_command(f"rm -f {shlex.quote(staged)}", timeout=120)
+
+    async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
+        remote_archive = f"{TRANSFER_ROOT}/{uuid.uuid4().hex}.tar.gz"
+        result = await self.run_command(
+            f"tar czf {shlex.quote(remote_archive)} -C {shlex.quote(source_dir)} .",
+            timeout=300,
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(f"failed to pack directory download: {result.stderr}")
+        with tempfile.TemporaryDirectory(prefix="cloudflare-download-") as tmp:
+            archive = Path(tmp) / "download.tar.gz"
+            try:
+                await self.download_file(remote_archive, archive)
+                target = Path(target_dir)
+                target.mkdir(parents=True, exist_ok=True)
+                with tarfile.open(archive, "r:gz") as tar:
+                    tar.extractall(target, filter="data")
+            finally:
+                await self.run_command(f"rm -f {shlex.quote(remote_archive)}", timeout=120)
+
+    def _file_path(self, path: str) -> str:
+        encoded = quote(path.lstrip("/"), safe="/")
+        return self._sandbox_path(f"/file/{encoded}")
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response, operation: str) -> None:
+        if not response.is_error:
+            return
+        raise CloudflareHTTPError(operation, response.status_code, response.text)

--- a/examples/aime/main.py
+++ b/examples/aime/main.py
@@ -136,9 +136,9 @@ class AimeMiniSweHarborEnv(HarborEnv):
 
 # ── Runnable entrypoint ──────────────────────────────────────────────────────
 
-MODEL = "Qwen/Qwen3.6-35B-A3B"
+MODEL = "Qwen/Qwen3.5-4B"
 VALIDATE_MODEL = "gpt-5.4-mini"
-TRAINING_ARGS = {"model": MODEL, "num_epochs": 1}
+TRAINING_ARGS = {"model": MODEL}
 
 
 def _constructor_args(args: argparse.Namespace) -> dict[str, Any]:

--- a/examples/aime/main.py
+++ b/examples/aime/main.py
@@ -1,9 +1,9 @@
 """AIME Harbor environment using the offline-installed Mini-SWE agent.
 
 The dataset (aime/aime@latest) resolves through Harbor at trainer runtime, so
-only the environment bundle is uploaded. Validation runs real Modal sandbox
-trials. Modal credentials are mandatory CLI arguments; they are bundled into
-the environment constructor args so trainer-side trials can reach Modal.
+only the environment bundle is uploaded. Validation runs real Modal or
+Cloudflare sandbox trials. Provider credentials ride in the environment bundle
+so trainer-side trials can reach the selected sandbox service.
 
 Import-safe: stages run only from the ``if __name__ == "__main__"`` block.
 """
@@ -13,18 +13,24 @@ from __future__ import annotations
 import argparse
 import asyncio
 import dataclasses
+import os
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any
+from types import ModuleType
+from typing import Any, Literal
 
+import cloudflare_environment as cloudflare_adapter
+import cloudflare_transport
 from benchmax.envs.environment import Environment
 from benchmax.envs.harbor import (
     BundledAgentSource,
     BundledHarborAgent,
+    CustomSandboxCredentials,
     HarborEnv,
     HarborTrialTemplate,
     ModalCredentials,
+    SandboxCredentials,
 )
 from castform.platform import ensure_session, upload_assets
 from harbor import (
@@ -37,6 +43,8 @@ from harbor import (
 from harness.aime_agent import MINI_SWE_AGENT_VERSION
 
 from benchmax.bundle import dump_bundle
+
+_CLOUDFLARE_LOCAL_MODULES = (cloudflare_transport, cloudflare_adapter)
 
 _HARNESS_SOURCE = BundledAgentSource.from_directory(
     Path(__file__).parent / "harness",
@@ -62,21 +70,54 @@ def mini_swe_harness(*, max_timeout_secs: float | None = None) -> BundledHarborA
     )
 
 
+SandboxProvider = Literal["modal", "cloudflare"]
+
+
+def _prepare_cloudflare_modules_for_ray() -> None:
+    """Carry the example-local adapter through Trainer's second Ray pickle."""
+
+    for module in _CLOUDFLARE_LOCAL_MODULES:
+        if not isinstance(module, ModuleType):
+            raise TypeError("Cloudflare local module capture received a non-module")
+        sys.modules[module.__name__] = module
+    try:
+        from ray import cloudpickle as ray_cloudpickle
+    except ImportError:
+        return
+    for module in _CLOUDFLARE_LOCAL_MODULES:
+        ray_cloudpickle.register_pickle_by_value(module)
+
+
 class AimeMiniSweHarborEnv(HarborEnv):
-    """AIME latest on Modal; the agent harness defaults to the offline Mini-SWE loop."""
+    """AIME latest on Modal or Cloudflare with the bundled Mini-SWE loop."""
 
     def __init__(
         self,
         *,
-        sandbox_credentials: ModalCredentials,
+        sandbox_credentials: SandboxCredentials,
+        sandbox_provider: SandboxProvider = "modal",
         harness: BundledHarborAgent | None = None,
         max_agent_timeout_secs: float | None = None,
+        max_concurrent_trials: int | None = 128,
     ) -> None:
         if harness is not None and max_agent_timeout_secs is not None:
             raise ValueError(
                 "max_agent_timeout_secs applies only to the default harness; "
                 "set max_timeout_sec on the custom harness config instead"
             )
+        if sandbox_provider == "modal":
+            if not isinstance(sandbox_credentials, ModalCredentials):
+                raise TypeError("Modal AIME requires ModalCredentials")
+            environment = TrialEnvironmentConfig(type=EnvironmentType.MODAL)
+        elif sandbox_provider == "cloudflare":
+            if sandbox_credentials.provider != "cloudflare":
+                raise ValueError("Cloudflare AIME requires cloudflare credentials")
+            _prepare_cloudflare_modules_for_ray()
+            environment = TrialEnvironmentConfig(
+                import_path="cloudflare_environment:AimeCloudflareEnvironment"
+            )
+        else:
+            raise ValueError(f"unsupported sandbox_provider: {sandbox_provider}")
         super().__init__(
             dataset=DatasetConfig(name="aime/aime", ref="latest"),
             eval_ratio=0.1,
@@ -84,32 +125,78 @@ class AimeMiniSweHarborEnv(HarborEnv):
                 agent=harness
                 if harness is not None
                 else mini_swe_harness(max_timeout_secs=max_agent_timeout_secs),
-                environment=TrialEnvironmentConfig(
-                    type=EnvironmentType.MODAL,
-                ),
+                environment=environment,
                 verifier=TrialVerifierConfig(),
                 trials_dir=Path("/tmp/castform-aime-harbor-trials"),
             ),
             sandbox_credentials=sandbox_credentials,
-            max_concurrent_trials=1000,
+            max_concurrent_trials=max_concurrent_trials,
         )
 
 
 # ── Runnable entrypoint ──────────────────────────────────────────────────────
 
-MODEL = "Qwen/Qwen3.5-4B"
+MODEL = "Qwen/Qwen3.6-35B-A3B"
 VALIDATE_MODEL = "gpt-5.4-mini"
-RUNTIME_DEPENDENCIES = ["harbor[modal]>=0.18.0,<0.19"]
-RUN_NAME = "aime"
-TRAINING_ARGS = {"model": MODEL}
+TRAINING_ARGS = {"model": MODEL, "num_epochs": 1}
 
 
 def _constructor_args(args: argparse.Namespace) -> dict[str, Any]:
+    if args.sandbox_provider == "modal":
+        if not args.modal_token_id or not args.modal_token_secret:
+            raise SystemExit("Modal requires --modal-token-id and --modal-token-secret")
+        credentials: SandboxCredentials = ModalCredentials(
+            token_id=args.modal_token_id,
+            token_secret=args.modal_token_secret,
+        )
+    else:
+        api_url = args.cloudflare_sandbox_api_url or os.environ.get("CLOUDFLARE_SANDBOX_API_URL")
+        api_key = args.cloudflare_sandbox_api_key or os.environ.get("CLOUDFLARE_SANDBOX_API_KEY")
+        if not api_url or not api_key:
+            raise SystemExit(
+                "Cloudflare requires CLOUDFLARE_SANDBOX_API_URL and "
+                "CLOUDFLARE_SANDBOX_API_KEY (environment variables or CLI flags)"
+            )
+        credentials = CustomSandboxCredentials(
+            provider="cloudflare",
+            values={
+                "CLOUDFLARE_SANDBOX_API_URL": api_url.rstrip("/"),
+                "CLOUDFLARE_SANDBOX_API_KEY": api_key,
+            },
+        )
     return {
-        "sandbox_credentials": ModalCredentials(
-            token_id=args.modal_token_id, token_secret=args.modal_token_secret
-        ),
+        "sandbox_credentials": credentials,
+        "sandbox_provider": args.sandbox_provider,
     }
+
+
+def _runtime_dependencies(provider: SandboxProvider) -> list[str]:
+    if provider == "modal":
+        return ["harbor[modal]>=0.18.0,<0.19"]
+    return ["harbor>=0.18.0,<0.19", "httpx>=0.27.0"]
+
+
+def _local_modules(provider: SandboxProvider) -> list[ModuleType]:
+    return list(_CLOUDFLARE_LOCAL_MODULES) if provider == "cloudflare" else []
+
+
+def _preflight_cloudflare(constructor_args: dict[str, Any]) -> None:
+    if constructor_args["sandbox_provider"] != "cloudflare":
+        return
+    import httpx
+
+    values = constructor_args["sandbox_credentials"].host_environment()
+    response = httpx.get(
+        f"{values['CLOUDFLARE_SANDBOX_API_URL']}/v1/openapi.json",
+        headers={"Authorization": f"Bearer {values['CLOUDFLARE_SANDBOX_API_KEY']}"},
+        timeout=30,
+    )
+    if response.is_error:
+        raise SystemExit(
+            f"Cloudflare Sandbox preflight failed (HTTP {response.status_code}): "
+            f"{response.text[:200]}"
+        )
+    print("Cloudflare Sandbox preflight: bridge credentials accepted")
 
 
 def generate_data(*, force: bool) -> None:
@@ -134,7 +221,7 @@ def validate(env: AimeMiniSweHarborEnv, uploaded_assets: Any) -> Any:
     return report
 
 
-def launch(uploaded_assets: Any, *, assume_yes: bool) -> str | None:
+def launch(uploaded_assets: Any, *, assume_yes: bool, run_name: str) -> str | None:
     from castform import config
     from castform.platform.client import TrainerClient
 
@@ -146,7 +233,7 @@ def launch(uploaded_assets: Any, *, assume_yes: bool) -> str | None:
 
     with TrainerClient() as trainer:
         run_id = trainer.launch_training_run(
-            name=RUN_NAME,
+            name=run_name,
             launcher_args=TRAINING_ARGS,
             **dataclasses.asdict(uploaded_assets),
         )
@@ -204,14 +291,25 @@ def main(argv: list[str] | None = None) -> int:
         help="skip the launch confirmation",
     )
     parser.add_argument(
+        "--sandbox-provider",
+        choices=("modal", "cloudflare"),
+        default="modal",
+    )
+    parser.add_argument(
         "--modal-token-id",
-        required=True,
         help="Modal token id for sandbox trials (bundled into constructor args).",
     )
     parser.add_argument(
         "--modal-token-secret",
-        required=True,
         help="Modal token secret for sandbox trials (bundled into constructor args).",
+    )
+    parser.add_argument(
+        "--cloudflare-sandbox-api-url",
+        help="deployed AIME Sandbox bridge URL (defaults to environment)",
+    )
+    parser.add_argument(
+        "--cloudflare-sandbox-api-key",
+        help="AIME Sandbox bridge bearer key (defaults to environment)",
     )
     args = parser.parse_args(argv)
     total_stages = {"data": 1, "validate": 4, "launch": 5}[args.action]
@@ -224,15 +322,18 @@ def main(argv: list[str] | None = None) -> int:
     # Built after the data early-return: harvey's harness capture clones the
     # LAB tree, which the data stage must not pay for.
     constructor_args = _constructor_args(args)
+    _preflight_cloudflare(constructor_args)
     ensure_session()
     print(f"[stage 2/{total_stages}] bundling environment")
     bundled_environment = dump_bundle(
         AimeMiniSweHarborEnv,
         constructor_args=constructor_args,
-        pip_dependencies=RUNTIME_DEPENDENCIES,
+        pip_dependencies=_runtime_dependencies(args.sandbox_provider),
+        local_modules=_local_modules(args.sandbox_provider),
     )
+    run_name = f"aime-{args.sandbox_provider}"
     print(f"[stage 3/{total_stages}] uploading environment")
-    uploaded_assets = upload_assets(bundle=bundled_environment, run_name=RUN_NAME)
+    uploaded_assets = upload_assets(bundle=bundled_environment, run_name=run_name)
     print(f"  env_cls_path: {uploaded_assets.env_cls_path}")
     print(f"  env_metadata_path: {uploaded_assets.env_metadata_path}")
     print(f"  dataset_path: {uploaded_assets.dataset_path}")
@@ -242,7 +343,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     if args.action == "launch":
         print(f"[stage 5/{total_stages}] launching training")
-        launch(uploaded_assets, assume_yes=args.yes)
+        launch(uploaded_assets, assume_yes=args.yes, run_name=run_name)
     return 0
 
 

--- a/examples/aime/pyproject.toml
+++ b/examples/aime/pyproject.toml
@@ -5,6 +5,7 @@ description = "AIME Harbor environment with an offline-installed Mini-SWE agent"
 requires-python = "==3.12.*"
 dependencies = [
     "harbor>=0.18.0,<0.19",
+    "httpx>=0.27.0",
     "mini-swe-agent==2.4.5",
     "numpy",
     "pydantic",

--- a/examples/aime/tests/test_aime_env.py
+++ b/examples/aime/tests/test_aime_env.py
@@ -2,11 +2,18 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from benchmax.bundle import dump_bundle, load_bundle
-from benchmax.envs.harbor import BundledAgentSource, BundledHarborAgent, ModalCredentials
+from benchmax.envs.harbor import (
+    BundledAgentSource,
+    BundledHarborAgent,
+    CustomSandboxCredentials,
+    ModalCredentials,
+)
+from cloudflare_environment import AIME_IMAGE, validate_aime_environment
 from harbor import EnvironmentType, TrialAgentConfig
 from harness.aime_agent import MINI_SWE_AGENT_VERSION, prefetch_wheels
 from main import AimeMiniSweHarborEnv
+
+from benchmax.bundle import dump_bundle, load_bundle
 
 
 def test_aime_constructor_uses_latest_dataset_and_bundled_agent() -> None:
@@ -33,6 +40,44 @@ def test_aime_agent_timeout_flows_into_trial_config() -> None:
     )
 
     assert env._trial.agent.config.max_timeout_sec == 120.0
+
+
+def test_aime_constructor_selects_cloudflare_custom_environment() -> None:
+    credentials = CustomSandboxCredentials(
+        provider="cloudflare",
+        values={
+            "CLOUDFLARE_SANDBOX_API_URL": "https://sandbox.example.workers.dev",
+            "CLOUDFLARE_SANDBOX_API_KEY": "sandbox-key",
+        },
+    )
+
+    env = AimeMiniSweHarborEnv(
+        sandbox_credentials=credentials,
+        sandbox_provider="cloudflare",
+    )
+
+    assert env._sandbox_credentials is credentials
+    assert env._trial.environment.type is None
+    assert env._trial.environment.import_path == "cloudflare_environment:AimeCloudflareEnvironment"
+
+
+def test_cloudflare_contract_accepts_aime_fixed_dockerfile(tmp_path: Path) -> None:
+    environment = tmp_path / "environment"
+    environment.mkdir()
+    (environment / "Dockerfile").write_text(
+        f"# benchmark canary\n\nFROM {AIME_IMAGE}\n\nWORKDIR /app\n\nENV TEST_DIR=/tests\n"
+    )
+
+    validate_aime_environment(environment)
+
+
+def test_cloudflare_contract_rejects_another_image(tmp_path: Path) -> None:
+    environment = tmp_path / "environment"
+    environment.mkdir()
+    (environment / "Dockerfile").write_text("FROM ubuntu:latest\n")
+
+    with pytest.raises(ValueError, match="verified fixed Dockerfile"):
+        validate_aime_environment(environment)
 
 
 def _custom_harness() -> BundledHarborAgent:

--- a/examples/aime/tests/test_workflow.py
+++ b/examples/aime/tests/test_workflow.py
@@ -28,7 +28,7 @@ def test_launch_reuses_the_assets_that_were_validated(monkeypatch) -> None:
     monkeypatch.setattr(
         example,
         "dump_bundle",
-        lambda cls, *, constructor_args, pip_dependencies: (
+        lambda cls, *, constructor_args, pip_dependencies, local_modules: (
             calls.append(("bundle", constructor_args)) or bundled_environment
         ),
     )
@@ -45,7 +45,7 @@ def test_launch_reuses_the_assets_that_were_validated(monkeypatch) -> None:
     monkeypatch.setattr(
         example,
         "launch",
-        lambda received, **kwargs: calls.append(("launch", received)) or "run-id",
+        lambda received, **kwargs: calls.append(("launch", (received, kwargs))) or "run-id",
     )
     monkeypatch.setattr(example, "ensure_session", lambda: None)
 
@@ -53,21 +53,34 @@ def test_launch_reuses_the_assets_that_were_validated(monkeypatch) -> None:
     assert calls == [
         (
             "bundle",
-            {"sandbox_credentials": ModalCredentials("modal-id", "modal-secret")},
+            {
+                "sandbox_credentials": ModalCredentials("modal-id", "modal-secret"),
+                "sandbox_provider": "modal",
+            },
         ),
-        ("upload", {"bundle": bundled_environment, "run_name": "aime"}),
+        ("upload", {"bundle": bundled_environment, "run_name": "aime-modal"}),
         ("validate", uploaded_assets),
-        ("launch", uploaded_assets),
+        (
+            "launch",
+            (
+                uploaded_assets,
+                {"assume_yes": True, "run_name": "aime-modal"},
+            ),
+        ),
     ]
 
 
-def test_main_requires_credential_arguments(capsys: pytest.CaptureFixture[str]) -> None:
-    with pytest.raises(SystemExit):
-        example.main(["data"])
+def test_data_does_not_require_sandbox_credentials() -> None:
+    assert example.main(["data"]) == 0
 
-    stderr = capsys.readouterr().err
-    for name in ("--modal-token-id", "--modal-token-secret"):
-        assert name in stderr
+
+def test_validate_requires_selected_provider_credentials(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit, match="Modal requires"):
+        example.main(["validate"])
+
+    assert "generating data" in capsys.readouterr().out
 
 
 def test_print_validation_surfaces_contract_diagnostics(capsys) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -171,7 +171,7 @@ wheels = [
 
 [[package]]
 name = "benchmax"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "packages/benchmax" }
 dependencies = [
     { name = "cloudpickle" },
@@ -217,6 +217,7 @@ version = "0.1.0"
 source = { editable = "examples/aime" }
 dependencies = [
     { name = "harbor" },
+    { name = "httpx" },
     { name = "mini-swe-agent" },
     { name = "numpy" },
     { name = "pydantic" },
@@ -233,6 +234,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "harbor", specifier = ">=0.18.0,<0.19" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "mini-swe-agent", specifier = "==2.4.5" },
     { name = "numpy" },
     { name = "pydantic" },
@@ -565,7 +567,7 @@ wheels = [
 
 [[package]]
 name = "castform"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "packages/castform" }
 dependencies = [
     { name = "benchmax" },
@@ -828,7 +830,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -853,34 +855,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1838,7 +1840,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1877,7 +1879,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1889,7 +1891,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1919,9 +1921,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1933,7 +1935,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },


### PR DESCRIPTION
## Summary

- add a prepared-image Cloudflare Standard-2 Worker and container deployment for AIME
- add the Harbor environment adapter and authenticated transport for remote exec and file transfer
- expose Cloudflare as an explicit AIME sandbox provider while keeping Modal as the default
- preserve the existing Qwen/Qwen3.5-4B training default
- add credential preflight, documentation, and focused tests

## Validation

- uv lock --check
- uv run ruff check examples/aime
- uv run ruff format --check examples/aime
- uv run pytest examples/aime/tests -q (13 passed)
- npm run typecheck
- real AIME Cloudflare validation: two locally orchestrated and two hosted rollout-service trials all finished with reward 1.0